### PR TITLE
graphql api auto apply auth fix

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -68,26 +68,76 @@ export async function pushResources(
     continueToPush = await context.amplify.confirmPrompt('Are you sure you want to continue?');
   }
 
+  let retryPush;
   if (continueToPush) {
-    try {
-      // Get current-cloud-backend's amplify-meta
-      const currentAmplifyMeta = stateManager.getCurrentMeta();
+    do {
+      retryPush = false;
+      try {
+        // Get current-cloud-backend's amplify-meta
+        const currentAmplifyMeta = stateManager.getCurrentMeta();
 
-      await providersPush(context, category, resourceName, filteredResources);
-      await onCategoryOutputsChange(context, currentAmplifyMeta);
-    } catch (err) {
-      // Handle the errors and print them nicely for the user.
-      if (!(err instanceof CustomPoliciesFormatError)) {
-        printer.error(`\n${err.message}`);
+        await providersPush(context, category, resourceName, filteredResources);
+        await onCategoryOutputsChange(context, currentAmplifyMeta);
+      } catch (err) {
+        if (await isValidGraphQLAuthError(err.message)) {
+          retryPush = await handleValidGraphQLAuthError(context, err.message);
+        }
+        if(!retryPush) {
+          // Handle the errors and print them nicely for the user.
+          context.print.error(`\n${err.message}`);
+          throw err;
+        }
       }
-      throw err;
-    }
+    } while (retryPush);
   } else {
     // there's currently no other mechanism to stop the execution of the postPush workflow in this case, so exiting here
     exitOnNextTick(1);
   }
 
   return continueToPush;
+}
+
+async function isValidGraphQLAuthError(message: string) {
+  if (message === `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`
+    || message === `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.`
+    || message === `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.`
+    || message === `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`
+    || message === `@auth directive with 'function' provider found, but the project has no Lambda authentication provider configured.`) {
+    return true;
+  }
+}
+
+async function handleValidGraphQLAuthError(context: $TSContext, message: string) {
+  if (message === `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`) {
+    await addGraphQLAuthRequirement(context, 'AWS_IAM');
+    return true;
+  } else if (!context?.parameters?.options?.yes) {
+    if (message === `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.`) {
+      await addGraphQLAuthRequirement(context, 'AMAZON_COGNITO_USER_POOLS');
+      return true;
+    } else if (message === `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.`) {
+      await addGraphQLAuthRequirement(context, 'OPENID_CONNECT')
+      return true;
+    } else if (message === `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`) {
+      await addGraphQLAuthRequirement(context, 'AWS_KEY');
+      return true;
+    } else if (message === `@auth directive with 'function' provider found, but the project has no Lambda authentication provider configured.`) {
+      await addGraphQLAuthRequirement(context, 'AWS_LAMBDA');
+      return true;
+    }
+  }
+  return false;
+}
+
+async function addGraphQLAuthRequirement(context, authType) {
+  return await context.amplify.invokePluginMethod(context, 'api', undefined, 'addGraphQLAuthorizationMode', [
+    context,
+    {
+      authType: authType,
+      printLeadText: true,
+      authSettings: undefined,
+    },
+  ]);
 }
 
 async function providersPush(context: $TSContext, category, resourceName, filteredResources) {

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -335,31 +335,8 @@ export async function transformGraphQLSchema(context, options) {
     sandboxModeEnabled,
   };
 
-  let transformerOutput;
-  let authSchemaErrors = false;
-  do {
-    try {
-    transformerOutput = await buildAPIProject(buildConfig);
-    authSchemaErrors = false;
-  } catch (err) {
-    authSchemaErrors = true;
-    if (err.message === `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`) {
-      authConfig.additionalAuthenticationProviders.push(await addGraphQLAuthRequirement(context, 'AWS_IAM'));
-    } else if (!context?.parameters?.options?.yes) {
-      if (err.message === `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.`) {
-        authConfig.additionalAuthenticationProviders.push(await addGraphQLAuthRequirement(context, 'AMAZON_COGNITO_USER_POOLS'));
-      } else if (err.message === `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.`) {
-        authConfig.additionalAuthenticationProviders.push(await addGraphQLAuthRequirement(context, 'OPENID_CONNECT'));
-      } else if (err.message === `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`) {
-        authConfig.additionalAuthenticationProviders.push(await addGraphQLAuthRequirement(context, 'AWS_KEY'));
-      } else {
-        throw err;
-      }
-    } else {
-      throw err;
-    }
-  }
-  } while (authSchemaErrors);
+  const transformerOutput = await buildAPIProject(buildConfig);
+
   context.print.success(`GraphQL schema compiled successfully.\n\nEdit your schema at ${schemaFilePath} or \
 place .graphql files in a directory at ${schemaDirPath}`);
 

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -396,13 +396,24 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject) {
     if (iterativeDeploymentWasInvoked) {
       await deploymentStateManager.failDeployment();
     }
-    spinner.fail('An error occurred when pushing the resources to the cloud');
-
+    if(!await canAutoResolveGraphQLAuthError(error.message)) {
+      spinner.fail('An error occurred when pushing the resources to the cloud');
+    }
     rollbackLambdaLayers(layerResources);
 
     logger('run', [resourceDefinition])(error);
 
     throw error;
+  }
+}
+
+async function canAutoResolveGraphQLAuthError(message: string) {
+  if (message === `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`
+    || message === `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.`
+    || message === `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.`
+    || message === `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`
+    || message === `@auth directive with 'function' provider found, but the project has no Lambda authentication provider configured.`) {
+    return true;
   }
 }
 

--- a/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/transform-graphql-schema.ts
@@ -511,32 +511,8 @@ export async function transformGraphQLSchema(context, options) {
     featureFlags: ff,
     sanityCheckRules: sanityCheckRulesList,
   };
-  let transformerOutput;
-  let authSchemaErrors = false;
-  do {
-    try {
-      transformerOutput = await buildAPIProject(buildConfig);
-      authSchemaErrors = false;
-    } catch (err) {
-      authSchemaErrors = true;
-      if (err.message === `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`) {
-        authConfig.additionalAuthenticationProviders.push(await addGraphQLAuthRequirement(context, 'AWS_IAM'));
-      } else if (!context?.parameters?.options?.yes) {
-        if (err.message === `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.`) {
-          authConfig.additionalAuthenticationProviders.push(await addGraphQLAuthRequirement(context, 'AMAZON_COGNITO_USER_POOLS'));
-        } else if (err.message === `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.`) {
-          authConfig.additionalAuthenticationProviders.push(await addGraphQLAuthRequirement(context, 'OPENID_CONNECT'));
-        } else if (err.message === `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.`) {
-          authConfig.additionalAuthenticationProviders.push(await addGraphQLAuthRequirement(context, 'AWS_KEY'));
-        } else {
-          throw err;
-        }
-      } else {
-        throw err;
-      }
-      buildConfig.transformersFactory = getTransformerFactory(context, resourceDir, authConfig);
-    }
-  } while (authSchemaErrors);
+
+  const transformerOutput = await buildAPIProject(buildConfig);
 
   context.print.success(`GraphQL schema compiled successfully.\n\nEdit your schema at ${schemaFilePath} or \
 place .graphql files in a directory at ${schemaDirPath}`);


### PR DESCRIPTION
#### Description of changes

Bug fix for GraphQL Api Auto Apply auth mode.

#### Description of how you validated changes

- yarn test passed.
- Manual testing.
  - Initialize a project amplify-dev init
  - add graphql api with default configuration  
  - update the schema to include cognito rules.
  - run amplify push and expect add auth prompts
  - push succeeds 

**Note:** 
More tests will be added with Lambda authorizer PR.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
